### PR TITLE
Fix einsum path in cp.einsum

### DIFF
--- a/gss/cacgmm/cacg_trainer.py
+++ b/gss/cacgmm/cacg_trainer.py
@@ -99,15 +99,13 @@ class ComplexAngularCentralGaussianTrainer:
             10 * cp.finfo(quadratic_form.dtype).tiny,
         )
 
+        einsum_path = ["einsum_path", (0, 2), (0, 1)]
         covariance = D * cp.einsum(
             "...dn,...Dn,...n->...dD",
             y,
             y.conj(),
             (saliency / quadratic_form),
-            # optimize='greedy',
-            # Without greedy the diagonal of the  covariance matrix is real
-            # valued, otherwise only approximately real values
-            # (i.e., values of 1e-17 for the imag part)
+            optimize=einsum_path,
         )
         assert cp.isfinite(quadratic_form).all()
         covariance /= cp.maximum(


### PR DESCRIPTION
Since we roughly know the shapes of the tensors, we can fix the einsum_path instead of computing the optimal path each time. 

Using the optimal path gives the following FLOP speedup in the CACG `_log_pdf`:

```
  Complete contraction:  cfdt,cfde,cfe,cfge,cfgt->cft
         Naive scaling:  6
     Optimized scaling:  5
      Naive FLOP count:  1.480e+10
  Optimized FLOP count:  9.699e+8
   Theoretical speedup:  1.526e+1
  Largest intermediate:  6.040e+7 elements
--------------------------------------------------------------------------------
scaling        BLAS                current                             remaining
--------------------------------------------------------------------------------
   4              0         cfe,cfde->cfed              cfdt,cfge,cfgt,cfed->cft
   5              0        cfed,cfge->cfdg                   cfdt,cfgt,cfdg->cft
   5              0        cfdg,cfdt->cfgt                        cfgt,cfgt->cft
   4              0         cfgt,cfgt->cft                              cft->cft
```

The main speedup will come from the CACG log_pdf computation (~1.5x). Note that the original implementation also had the optimal path contraction, but this optimal path was being computed at every iteration, which is very time-consuming (see [here](https://optimized-einsum.readthedocs.io/en/stable/optimal_path.html)). Instead of doing this, we now fix the optimal path.