### PR TITLE
Changes to work with new cupy version

### DIFF
--- a/gss/beamformer/beamform.py
+++ b/gss/beamformer/beamform.py
@@ -48,7 +48,7 @@ def get_power_spectral_density_matrix(
         mask = cp.copy(mask)
 
         # normalize
-        if mask.dtype == cp.bool:
+        if mask.dtype == bool:
             mask = cp.asfarray(mask)
 
         if normalize:

--- a/gss/cacgmm/cacgmm_trainer.py
+++ b/gss/cacgmm/cacgmm_trainer.py
@@ -105,7 +105,7 @@ class CACGMMTrainer:
 
         if source_activity_mask is not None:
             assert (
-                source_activity_mask.dtype == cp.bool
+                source_activity_mask.dtype == bool
             ), source_activity_mask.dtype  # noqa
             assert source_activity_mask.shape[-2:] == (num_classes, num_observations), (
                 source_activity_mask.shape,

--- a/gss/cacgmm/utils.py
+++ b/gss/cacgmm/utils.py
@@ -71,7 +71,7 @@ def log_pdf_to_affiliation(
     affiliation *= weight
 
     if source_activity_mask is not None:
-        assert source_activity_mask.dtype == cp.bool, source_activity_mask.dtype  # noqa
+        assert source_activity_mask.dtype == bool, source_activity_mask.dtype  # noqa
         affiliation *= source_activity_mask
 
     denominator = cp.maximum(

--- a/gss/core/gss.py
+++ b/gss/core/gss.py
@@ -17,7 +17,7 @@ class GSS:
         initialization = initialization / cp.sum(initialization, keepdims=True, axis=0)
         initialization = cp.repeat(initialization[None, ...], 513, axis=0)
 
-        source_active_mask = cp.asarray(acitivity_freq, dtype=cp.bool)
+        source_active_mask = cp.asarray(acitivity_freq, dtype=bool)
         source_active_mask = cp.repeat(source_active_mask[None, ...], 513, axis=0)
 
         cacGMM = CACGMMTrainer()


### PR DESCRIPTION
The new CuPy uses numpy dtypes which has deprecated native dtypes (see [this](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated)). Basically this means we have to use `bool` instead of `cp.bool`.

The other change is that since CuPy 12, ufunc types are now natively supported. So we can just use `cp.add.at` instead of casting to NumPy. I have kept this change back-compatible with older CuPy versions for now since CuPy 12 is still in pre-release stage.