### PR TITLE
[Fix] Use number of channels when calculating BAN

### DIFF
--- a/gss/beamformer/beamform.py
+++ b/gss/beamformer/beamform.py
@@ -98,7 +98,7 @@ def blind_analytic_normalization(vector, noise_psd_matrix):
         vector,
         optimize=einsum_path,
     )
-    nominator = cp.sqrt(nominator)
+    nominator = cp.sqrt(nominator / vector.shape[-1])
 
     einsum_path = ["einsum_path", (0, 1), (0, 1)]
     denominator = cp.einsum(


### PR DESCRIPTION
It seems the current implementation is missing a scaling by $M^{-1/2}$ when calculating BAN.
This results in a gain of $10 \log_{10} M~\text{dB}$, which sometimes results in clipping depending on $M$ and the input signal level.

Please refer to eq. (17) in Warsitz, Blind Acoustic Beamforming Based on Generalized Eigenvalue Decomposition, 2007.