### PR TITLE
Fixed code for right context equal to 0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         args: ['--select=E9,F63,F7,F82']
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: [--profile=black]

--- a/gss/core/enhancer.py
+++ b/gss/core/enhancer.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
@@ -25,7 +24,6 @@ logging.basicConfig(
     datefmt="%Y-%m-%d:%H:%M:%S",
     level=logging.INFO,
 )
-logging.captureWarnings(True)
 
 
 def get_enhancer(
@@ -364,8 +362,12 @@ class Enhancer:
         # Trim x_hat to original length of cut
         if right_context > 0:
             x_hat = x_hat[:, left_context:-right_context]
+        elif right_context == 0:
+            x_hat = x_hat[:, left_context:]
         else:
-            warnings.warn(f"Right context is less or equal to zero. Only left context is used.")
+            logging.warning(
+                f"Right context is less than zero. Only left context is used."
+            )
             x_hat = x_hat[:, left_context:]
 
         return x_hat

--- a/gss/core/enhancer.py
+++ b/gss/core/enhancer.py
@@ -360,6 +360,11 @@ class Enhancer:
             x_hat = x_hat[np.newaxis, :]
 
         # Trim x_hat to original length of cut
-        x_hat = x_hat[:, left_context:-right_context]
+        if right_context > 0:
+            x_hat = x_hat[:, left_context:-right_context]
+        elif right_context == 0:
+            x_hat = x_hat[:, left_context:]
+        else:
+            raise ValueError(f"Right context {right_context} is less than 0")
 
         return x_hat

--- a/gss/core/enhancer.py
+++ b/gss/core/enhancer.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
@@ -24,6 +25,7 @@ logging.basicConfig(
     datefmt="%Y-%m-%d:%H:%M:%S",
     level=logging.INFO,
 )
+logging.captureWarnings(True)
 
 
 def get_enhancer(
@@ -362,9 +364,8 @@ class Enhancer:
         # Trim x_hat to original length of cut
         if right_context > 0:
             x_hat = x_hat[:, left_context:-right_context]
-        elif right_context == 0:
-            x_hat = x_hat[:, left_context:]
         else:
-            raise ValueError(f"Right context {right_context} is less than 0")
+            warnings.warn(f"Right context is less or equal to zero. Only left context is used.")
+            x_hat = x_hat[:, left_context:]
 
         return x_hat


### PR DESCRIPTION
When `right_context` is set to 0 (which is its default value in function args), the line changed in this PR becomes:
```
x_hat = x_hat[:, left_context:-0]
```
which basically makes `x_hat` empty matrix of size (number_of_channels,0). The conditioning proposed in this PR prevents from this.