### PR TITLE
fix numpy cupy depreacted type

### DIFF
--- a/gss/beamformer/beamform.py
+++ b/gss/beamformer/beamform.py
@@ -48,7 +48,7 @@ def get_power_spectral_density_matrix(
         mask = cp.copy(mask)
 
         # normalize
-        if mask.dtype == cp.bool:
+        if mask.dtype == cp.bool_:
             mask = cp.asfarray(mask)
 
         if normalize:

--- a/gss/cacgmm/cacgmm_trainer.py
+++ b/gss/cacgmm/cacgmm_trainer.py
@@ -105,7 +105,7 @@ class CACGMMTrainer:
 
         if source_activity_mask is not None:
             assert (
-                source_activity_mask.dtype == cp.bool
+                source_activity_mask.dtype == cp.bool_
             ), source_activity_mask.dtype  # noqa
             assert source_activity_mask.shape[-2:] == (num_classes, num_observations), (
                 source_activity_mask.shape,

--- a/gss/cacgmm/utils.py
+++ b/gss/cacgmm/utils.py
@@ -71,7 +71,7 @@ def log_pdf_to_affiliation(
     affiliation *= weight
 
     if source_activity_mask is not None:
-        assert source_activity_mask.dtype == cp.bool, source_activity_mask.dtype  # noqa
+        assert source_activity_mask.dtype == cp.bool_, source_activity_mask.dtype  # noqa
         affiliation *= source_activity_mask
 
     denominator = cp.maximum(

--- a/gss/core/gss.py
+++ b/gss/core/gss.py
@@ -17,7 +17,7 @@ class GSS:
         initialization = initialization / cp.sum(initialization, keepdims=True, axis=0)
         initialization = cp.repeat(initialization[None, ...], F, axis=0)
 
-        source_active_mask = cp.asarray(activity_freq, dtype=cp.bool)
+        source_active_mask = cp.asarray(activity_freq, dtype=cp.bool_)
         source_active_mask = cp.repeat(source_active_mask[None, ...], F, axis=0)
 
         cacGMM = CACGMMTrainer()

--- a/gss/utils/data_utils.py
+++ b/gss/utils/data_utils.py
@@ -217,7 +217,7 @@ def activity_time_to_frequency(
     stft_fading,
     stft_pad=True,
 ):
-    assert np.asarray(time_activity).dtype != np.object, (
+    assert np.asarray(time_activity).dtype != object, (
         type(time_activity),
         np.asarray(time_activity).dtype,
     )


### PR DESCRIPTION
fix [module 'numpy' has no attribute 'object'](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecationsl)

fix [module 'cupy' has no attribute 'bool'](https://github.com/cupy/cupy/pull/4790/files)