### PR TITLE
do not chunk when performing beamforming

### DIFF
--- a/gss/bin/modes/utils.py
+++ b/gss/bin/modes/utils.py
@@ -56,7 +56,9 @@ def rttm_to_supervisions_(rttm_path, out_path, channels):
 def gpu_check_(num_jobs, cmd):
     if cmd == "run.pl" and num_jobs > 1:
         used_devices = os.environ.get("CUDA_VISIBLE_DEVICES", "0").split(",")
-        assert num_jobs <= len(used_devices), f"You are requesting {num_jobs} jobs but you have {len(used_devices)} GPUs available. Exiting !"
+        assert num_jobs <= len(
+            used_devices
+        ), f"You are requesting {num_jobs} jobs but you have {len(used_devices)} GPUs available. Exiting !"
         for device in used_devices:
             grep_res = subprocess.check_output(("nvidia-smi", "-i", f"{device}", "-q"))
             check = re.findall("Compute Mode\s+:\sDefault", str(grep_res))

--- a/gss/core/enhancer.py
+++ b/gss/core/enhancer.py
@@ -351,18 +351,9 @@ class Enhancer:
         distortion_mask = cp.sum(masks, axis=0) - target_mask
 
         logging.debug("Applying beamforming with computed masks")
-        X_hat = []
-        for i in range(num_chunks):
-            st = i * chunk_size
-            en = min(F, (i + 1) * chunk_size)
-            X_hat_chunk = self.bf_block(
-                Obs[:, :, st:en],
-                target_mask=target_mask[:, st:en],
-                distortion_mask=distortion_mask[:, st:en],
-            )
-            X_hat.append(X_hat_chunk)
-
-        X_hat = cp.concatenate(X_hat, axis=1)  # freq axis again
+        X_hat = self.bf_block(
+            Obs, target_mask=target_mask, distortion_mask=distortion_mask
+        )
 
         logging.debug("Computing inverse STFT")
         x_hat = self.istft(X_hat)  # returns a numpy array


### PR DESCRIPTION
as pointed out by @kamo-naoyuki, there are currently problems when doing the beamforming due to the fact that the a-posteriori SNR reference channel selection is performed for each freq chunk independently (and this requires a reduction over the freq axis). 
The easy fix is to avoid to chunk frequencies when doing the beamfoming. Hopefully it is still ok and will not lead to OOMs